### PR TITLE
Simplify README, use FixieCorpus.createTool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -1,15 +1,6 @@
 # fixie-sidekick-template
 Template project for building a Fixie Sidekick.
 
-You need to create a .env file in the root folder and add two variables:
-
-```
-FIXIE_API_URL=https://beta.fixie.ai
-FIXIE_API_KEY=<your API key for Fixie>
-```
-
-Note: the FIXIE_API_KEY value will be a 175 character string.
-
 There are a number of places in the template marked "TODO". You should update the project in these places for your sidekick.
 
-You also need to run ```yarn install``` prior to deploying. Then you can deploy with ```FIXIE_API_URL='https://beta.fixie.ai' npx @fixieai/fixie deploy```
+You also need to run ```npm install``` prior to deploying. Then you can deploy with ```npm run deploy```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fixie-sidekick-template",
   "version": "0.1.0",
   "devDependencies": {
-    "@fixieai/sdk": "*",
+    "@fixieai/fixie": "^1.0.16",
     "@tsconfig/node18": "^2.0.1",
     "@types/lodash": "^4.14.198",
     "typescript": "5.1.3"
@@ -10,7 +10,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "npm run build && fixie-serve-bin --packagePath ./dist/index.js --port 8080",
+    "dev": "npm run build && npm run serve",
     "typecheck": "tsc -p tsconfig.json",
     "build": "npm run typecheck",
     "prepack": "npm run build",
@@ -18,8 +18,8 @@
     "deploy": "fixie deploy"
   },
   "dependencies": {
-    "@fixieai/fixie": "^1.0.16",
-    "ai-jsx": "0.15.0"
+    "@fixieai/sdk": "*",
+    "ai-jsx": ">=0.17.0"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "deploy": "fixie deploy"
   },
   "dependencies": {
-    "@fixieai/sdk": "*",
+    "@fixieai/sdk": ">=1.0.5",
     "ai-jsx": ">=0.17.0"
   },
   "files": [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,3 @@
-/// <reference lib="dom" />
-
 import { Tool } from "ai-jsx/batteries/use-tools";
 import {
   YourSidekickSystemMessage,
@@ -7,54 +5,24 @@ import {
 } from "./system-message.js";
 import { FixieCorpus } from "ai-jsx/batteries/docs";
 import { Sidekick } from "ai-jsx/sidekick";
-import _ from "lodash";
 
 //TODO: Replace with your Fixie Corpus ID
-const FIXIE_CORPUS_ID = "";
+const FIXIE_CORPUS_ID: string = undefined;
 
 if (!FIXIE_CORPUS_ID) {
   throw new Error("Please set a FIXIE_CORPUS_ID in src/index.tsx");
 }
 
-const fullCorpus = new FixieCorpus(FIXIE_CORPUS_ID);
 const systemMessage = <YourSidekickSystemMessage />;
 
 const tools: Record<string, Tool> = {
   // TODO: To help the model understand when to call this tool, name the function
   // something more descriptive like 'lookUpAcmeCompanyKnowledgeBase'.
   // For more tips on using Tools, see: https://docs.ai-jsx.com/tutorial/part7-tools
-  lookUpKnowledgeBase: {
-    // Name this function something like 'lookUpAcmeCompanyKnowledgeBase".
-    description:
-      "A tool for looking additional information to help answer the user query.",
-    parameters: {
-      query: {
-        description:
-          "The search query. It will be embedded and used in a vector search against the corpus.",
-        type: "string",
-        required: true,
-      },
-    },
-    func: async ({ query }) => {
-      const results = await fullCorpus.search(query);
-      /**
-       * Reverse the array so the closest chunk is listed last (closest to the user query).
-       *
-       * N.B.: The results will not be sorted by `score`, because the point of
-       * the reranker is to reorder them.
-       */
-      results.reverse();
-
-      /**
-       * Ideally we'd pass a limit, but I don't know how high a limit we'll need to set to have enough results after
-       * the dedupe.
-       */
-      return JSON.stringify({
-        kind: "docs",
-        results: _.uniqBy(results, (result) => result.chunk.content),
-      });
-    },
-  },
+  lookUpKnowledgeBase: FixieCorpus.createTool(
+    FIXIE_CORPUS_ID,
+    "A tool for looking additional information to help answer the user query."
+  ),
   /*
   anotherPossibleTool: {
     description:


### PR DESCRIPTION
- Remove (no longer necessary) `.env` discussion from README
- Add `dist` to `.gitignore`
- Rework dependencies so that the Fixie CLI is a dev dependency and the Fixie SDK is a runtime dependency
- Use `FixieCorpus.createTool` to simplify tool creation
- Make failing to set `FIXIE_CORPUS_ID` a compile-time error