### PR TITLE
Using fixie@latest package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fixie-sidekick-template",
   "version": "0.1.0",
   "devDependencies": {
-    "@fixieai/fixie": "^1.0.16",
+    "fixie": "latest",
     "@tsconfig/node18": "^2.0.1",
     "@types/lodash": "^4.14.198",
     "typescript": "5.1.3"
@@ -14,7 +14,7 @@
     "typecheck": "tsc -p tsconfig.json",
     "build": "npm run typecheck",
     "prepack": "npm run build",
-    "serve": "fixie serve",
+    "serve": "AIJSX_LOG=warn fixie serve",
     "deploy": "fixie deploy"
   },
   "dependencies": {


### PR DESCRIPTION
I tried running `npm run dev` and it failed. This is likely because the package versions are too old and we are still using `@fixieai/fixie` instead of `fixie` NPM package. I'm not a Node.js programmer, so let me if the `latest` trick I did is wrong.

I also added `AIJSX_LOG=warn` to `serve` command to let people know it exists at least. `warn` is unlikely to spam the console, so it's probably okay :?